### PR TITLE
adjust category for openspeedtest

### DIFF
--- a/ix-dev/community/open-speed-test/app.yaml
+++ b/ix-dev/community/open-speed-test/app.yaml
@@ -1,7 +1,7 @@
 app_version: v2.0.6
 capabilities: []
 categories:
-- network
+- networking
 description: "SpeedTest by OpenSpeedTest\u2122 is a Free and Open-Source HTML5 Network\
   \ Performance Estimation Tool"
 home: https://openspeedtest.com


### PR DESCRIPTION
OpenSpeedTest is currently in its own category « network » but an appropriate category « networking » suits also and contains other similar apps this avoids confusion